### PR TITLE
Fix control terminal query responses

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -785,6 +785,10 @@ const Client = struct {
     alloc: std.mem.Allocator,
     socket_fd: i32,
     kind: ClientKind = .terminal,
+    // True only for real terminal clients that can send terminal-query
+    // responses back to the PTY via Input frames. Control/tail clients consume
+    // rendered output but do not answer PTY-side terminal queries.
+    responds_to_terminal_queries: bool = false,
     has_pending_output: bool = false,
     read_buf: ipc.SocketBuffer,
     write_buf: std.ArrayList(u8),
@@ -894,7 +898,6 @@ const Daemon = struct {
     cwd: []const u8 = "",
     has_pty_output: bool = false,
     has_had_client: bool = false,
-    has_terminal_client: bool = false, // true only after a real attach (.Init received)
     created_at: u64, // unix timestamp (ns)
     is_task_mode: bool = false, // flag for when session is run as a task
     task_exit_code: ?u8 = null, // null = running or n/a, set when task completes
@@ -903,6 +906,7 @@ const Daemon = struct {
     is_fish: bool = false, // true if the session's foreground shell is fish
     pty_fd: i32 = -1, // set by daemonLoop so handleRun can probe the foreground process
     pty_write_buf: std.ArrayList(u8) = .empty,
+    terminal_query_pending: std.ArrayList(u8) = .empty,
     start_child_on_init: bool = false,
     child_start_fd: posix.fd_t = -1,
 
@@ -910,6 +914,7 @@ const Daemon = struct {
         self.closeChildStartFd();
         self.clients.deinit(self.alloc);
         self.pty_write_buf.deinit(self.alloc);
+        self.terminal_query_pending.deinit(self.alloc);
         self.alloc.free(self.socket_path);
     }
 
@@ -955,6 +960,13 @@ const Daemon = struct {
             self.alloc.destroy(client);
         }
         self.clients.clearRetainingCapacity();
+    }
+
+    fn hasTerminalQueryResponder(self: *const Daemon) bool {
+        for (self.clients.items) |client| {
+            if (client.responds_to_terminal_queries) return true;
+        }
+        return false;
     }
 
     pub fn closeClient(self: *Daemon, client: *Client, i: usize, shutdown_on_last: bool) bool {
@@ -1343,11 +1355,11 @@ const Daemon = struct {
 
         try self.applyClientResize(pty_fd, term, resize);
 
-        // Mark that we've had a client init, so subsequent clients get terminal state
-        // (KKL flattened the `if has_had_client` wrapper). has_terminal_client
-        // gates DA-query relay (upstream c654778).
+        // Mark that a real terminal client has initialized. Only real terminal
+        // clients can answer terminal queries from the PTY; control clients
+        // receive rendered frames and must not suppress daemon-side responses.
+        client.responds_to_terminal_queries = true;
         self.has_had_client = true;
-        self.has_terminal_client = true;
         self.releaseChildStart();
 
         std.log.debug("init resize rows={d} cols={d}", .{ resize.rows, resize.cols });
@@ -1412,7 +1424,6 @@ const Daemon = struct {
 
         try self.applyClientResize(pty_fd, term, resize);
         self.has_had_client = true;
-        self.has_terminal_client = true;
         self.releaseChildStart();
 
         std.log.debug("control init resize rows={d} cols={d}", .{ resize.rows, resize.cols });
@@ -3249,16 +3260,23 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
                     vt_stream.nextSlice(buf[0..n]);
                     daemon.has_pty_output = true;
 
-                    // When no real terminal client has attached yet, respond to
-                    // terminal queries (e.g. DA1/DA2) on behalf of the terminal.
-                    // This prevents fish from waiting 10s for unanswered queries.
-                    // `has_terminal_client` is only set when a client sends .Init
-                    // (a real zmx attach), not when a `zmx run` tail-only client
-                    // connects.
-                    if (!daemon.has_terminal_client and
+                    // When no real terminal client is attached, respond to
+                    // terminal queries on behalf of the terminal. Control clients
+                    // consume rendered frames but cannot answer PTY queries, and
+                    // tail-only clients (`zmx run`) are not terminal emulators.
+                    if (!daemon.hasTerminalQueryResponder() and
+                        (daemon.clients.items.len == 0 or daemon.has_had_client) and
                         daemon.pty_write_buf.items.len < Daemon.PTY_WRITE_BUF_MAX)
                     {
-                        util.respondToDeviceAttributes(daemon.alloc, &daemon.pty_write_buf, buf[0..n]);
+                        const cursor = term.screens.active.cursor;
+                        util.respondToTerminalQueries(
+                            daemon.alloc,
+                            &daemon.pty_write_buf,
+                            &daemon.terminal_query_pending,
+                            buf[0..n],
+                            @as(usize, @intCast(cursor.y)) + 1,
+                            @as(usize, @intCast(cursor.x)) + 1,
+                        );
                     }
 
                     // In run mode, scan output for exit code marker

--- a/src/util.zig
+++ b/src/util.zig
@@ -143,45 +143,135 @@ const DA1_QUERY = "\x1b[c";
 const DA1_QUERY_EXPLICIT = "\x1b[0c";
 const DA2_QUERY = "\x1b[>c";
 const DA2_QUERY_EXPLICIT = "\x1b[>0c";
+const DSR_STATUS_QUERY = "\x1b[5n";
+const CPR_QUERY = "\x1b[6n";
 const DA1_RESPONSE = "\x1b[?62;22c";
 const DA2_RESPONSE = "\x1b[>1;10;0c";
+const DSR_STATUS_RESPONSE = "\x1b[0n";
 
-pub fn respondToDeviceAttributes(alloc: std.mem.Allocator, buf: *std.ArrayList(u8), data: []const u8) void {
-    // Scan for DA queries in PTY output and respond on behalf of the terminal.
-    // This handles the case where no client is attached (e.g. zmx run)
-    // and the shell (e.g. fish) sends a DA query that would otherwise go unanswered.
+const TERMINAL_QUERY_PREFIXES = [_][]const u8{
+    DA1_QUERY,
+    DA1_QUERY_EXPLICIT,
+    DA2_QUERY,
+    DA2_QUERY_EXPLICIT,
+    DSR_STATUS_QUERY,
+    CPR_QUERY,
+};
+const MAX_TERMINAL_QUERY_PREFIX_LEN = terminalQueryPrefixLen();
+
+pub fn respondToTerminalQueries(
+    alloc: std.mem.Allocator,
+    buf: *std.ArrayList(u8),
+    pending: *std.ArrayList(u8),
+    data: []const u8,
+    cursor_row: usize,
+    cursor_col: usize,
+) void {
+    // Scan for terminal queries in PTY output and respond on behalf of the
+    // terminal when no real terminal client is currently attached. Responses are
+    // queued into the daemon's pty_write_buf (not written directly), so they
+    // preserve ordering with any already-buffered input.
     //
-    // Responses are queued into the daemon's pty_write_buf (not written
-    // directly) so they don't interleave with any already-buffered input —
-    // e.g. a large `zmx run` payload still draining after the client
-    // disconnected.
-    //
-    // DA1 query: ESC [ c  or  ESC [ 0 c
-    // DA2 query: ESC [ > c  or  ESC [ > 0 c
-    // DA1 response (from terminal): ESC [ ? ... c  (has '?' after '[')
-    //
-    // We must NOT match DA responses (which contain '?') as queries.
+    // Keep a tiny suffix buffer so queries split across PTY reads are still
+    // recognized without introducing a full parser or retaining arbitrary data.
+    var combined: std.ArrayList(u8) = .empty;
+    defer combined.deinit(alloc);
+
+    const scan_data = blk: {
+        if (pending.items.len == 0) break :blk data;
+        combined.appendSlice(alloc, pending.items) catch break :blk data;
+        combined.appendSlice(alloc, data) catch break :blk data;
+        pending.clearRetainingCapacity();
+        break :blk combined.items;
+    };
+
     var i: usize = 0;
-    while (i < data.len) {
-        if (data[i] == '\x1b' and i + 1 < data.len and data[i + 1] == '[') {
-            // Skip DA responses which have '?' after CSI
-            if (i + 2 < data.len and data[i + 2] == '?') {
-                i += 3;
-                continue;
-            }
-            if (matchSeq(data[i..], DA2_QUERY) or matchSeq(data[i..], DA2_QUERY_EXPLICIT)) {
-                buf.appendSlice(alloc, DA2_RESPONSE) catch {};
-            } else if (matchSeq(data[i..], DA1_QUERY) or matchSeq(data[i..], DA1_QUERY_EXPLICIT)) {
-                buf.appendSlice(alloc, DA1_RESPONSE) catch {};
-            }
+    while (i < scan_data.len) {
+        if (matchSeq(scan_data[i..], DA2_QUERY) or matchSeq(scan_data[i..], DA2_QUERY_EXPLICIT)) {
+            buf.appendSlice(alloc, DA2_RESPONSE) catch {};
+        } else if (matchSeq(scan_data[i..], DA1_QUERY) or matchSeq(scan_data[i..], DA1_QUERY_EXPLICIT)) {
+            buf.appendSlice(alloc, DA1_RESPONSE) catch {};
+        } else if (matchSeq(scan_data[i..], DSR_STATUS_QUERY)) {
+            buf.appendSlice(alloc, DSR_STATUS_RESPONSE) catch {};
+        } else if (matchSeq(scan_data[i..], CPR_QUERY)) {
+            // Cursor position reflects ghostty-vt state after the current PTY
+            // chunk is applied. Shells normally query and then block, so this
+            // is precise for the stall cases this responder handles.
+            buf.writer(alloc).print("\x1b[{d};{d}R", .{ cursor_row, cursor_col }) catch {};
         }
         i += 1;
     }
+
+    rememberTerminalQueryPrefix(alloc, pending, scan_data);
+}
+
+fn rememberTerminalQueryPrefix(alloc: std.mem.Allocator, pending: *std.ArrayList(u8), data: []const u8) void {
+    pending.clearRetainingCapacity();
+    var suffix_len = @min(MAX_TERMINAL_QUERY_PREFIX_LEN, data.len);
+    while (suffix_len > 0) : (suffix_len -= 1) {
+        const suffix = data[data.len - suffix_len ..];
+        for (TERMINAL_QUERY_PREFIXES) |query| {
+            if (suffix.len < query.len and std.mem.eql(u8, suffix, query[0..suffix.len])) {
+                pending.appendSlice(alloc, suffix) catch {};
+                return;
+            }
+        }
+    }
+}
+
+fn terminalQueryPrefixLen() usize {
+    comptime var max_len: usize = 0;
+    inline for (TERMINAL_QUERY_PREFIXES) |query| {
+        max_len = @max(max_len, query.len - 1);
+    }
+    return max_len;
 }
 
 fn matchSeq(data: []const u8, seq: []const u8) bool {
     if (data.len < seq.len) return false;
     return std.mem.eql(u8, data[0..seq.len], seq);
+}
+
+fn expectTerminalQueryResponse(data: []const u8, expected: []const u8) !void {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    var pending: std.ArrayList(u8) = .empty;
+    defer pending.deinit(std.testing.allocator);
+    respondToTerminalQueries(std.testing.allocator, &buf, &pending, data, 12, 34);
+    try std.testing.expectEqualStrings(expected, buf.items);
+}
+
+fn expectSplitTerminalQueryResponse(first: []const u8, second: []const u8, expected: []const u8) !void {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    var pending: std.ArrayList(u8) = .empty;
+    defer pending.deinit(std.testing.allocator);
+    respondToTerminalQueries(std.testing.allocator, &buf, &pending, first, 12, 34);
+    respondToTerminalQueries(std.testing.allocator, &buf, &pending, second, 12, 34);
+    try std.testing.expectEqualStrings(expected, buf.items);
+}
+
+test "terminal query responder: DA variants" {
+    try expectTerminalQueryResponse("\x1b[c", DA1_RESPONSE);
+    try expectTerminalQueryResponse("\x1b[0c", DA1_RESPONSE);
+    try expectTerminalQueryResponse("\x1b[>c", DA2_RESPONSE);
+    try expectTerminalQueryResponse("\x1b[>0c", DA2_RESPONSE);
+}
+
+test "terminal query responder: split DA" {
+    try expectSplitTerminalQueryResponse("\x1b[", "c", DA1_RESPONSE);
+}
+
+test "terminal query responder: DSR and CPR" {
+    try expectTerminalQueryResponse("\x1b[5n", DSR_STATUS_RESPONSE);
+    try expectTerminalQueryResponse("\x1b[6n", "\x1b[12;34R");
+}
+
+test "terminal query responder: ignores terminal responses" {
+    try expectTerminalQueryResponse("\x1b[?62;22c", "");
+    try expectTerminalQueryResponse("\x1b[>1;10;0c", "");
+    try expectTerminalQueryResponse("\x1b[0n", "");
+    try expectTerminalQueryResponse("\x1b[12;34R", "");
 }
 
 /// OSC 133;A (prompt start) marker.

--- a/test/session.bats
+++ b/test/session.bats
@@ -40,7 +40,11 @@ load test_helper
 }
 
 @test "run: blocking returns after command completes" {
-  run timeout 5 env SHELL=/bin/bash "$ZMX" run test-blocking echo hello
+  run timeout 10 env SHELL=/bin/bash "$ZMX" run test-blocking echo hello
+  if [ "$status" -ne 0 ]; then
+    echo "status=$status" >&3
+    echo "$output" >&3
+  fi
   [ "$status" -eq 0 ]
   [[ "$output" == *"session \"test-blocking\" created"* ]]
 }

--- a/test/terminal_queries.bats
+++ b/test/terminal_queries.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+# Terminal-query behavior for tail-only and control clients.
+
+load test_helper
+
+terminal_query_probe() {
+  env ZMX="$ZMX" ZMX_DIR="$ZMX_DIR" python3 "$REPO_DIR/test/terminal_query_probe.py" "$@"
+}
+
+assert_probe_ok() {
+  if [ "$status" -ne 0 ]; then
+    echo "status=$status" >&3
+    echo "$output" >&3
+  fi
+  [ "$status" -eq 0 ]
+}
+
+@test "control: answers DA1 and DA2 terminal queries" {
+  run terminal_query_probe --mode control --session tq-da1 --query '\033[c' --expect 1b5b3f36323b323263
+  assert_probe_ok
+
+  run terminal_query_probe --mode control --session tq-da2 --query '\033[>c' --expect 1b5b3e313b31303b3063
+  assert_probe_ok
+}
+
+@test "control: answers explicit DA1 and DA2 terminal queries" {
+  run terminal_query_probe --mode control --session tq-da1x --query '\033[0c' --expect 1b5b3f36323b323263
+  assert_probe_ok
+
+  run terminal_query_probe --mode control --session tq-da2x --query '\033[>0c' --expect 1b5b3e313b31303b3063
+  assert_probe_ok
+}
+
+@test "run: answers DA1 split across PTY output reads" {
+  run terminal_query_probe --mode run --session tq-split --split --expect 1b5b3f36323b323263
+  assert_probe_ok
+}
+
+@test "control: answers DSR status and CPR cursor queries" {
+  run terminal_query_probe --mode control --session tq-dsr --query '\033[5n' --expect 1b5b306e
+  assert_probe_ok
+
+  run terminal_query_probe --mode control --session tq-cpr --query '\033[6n' --expect-regex '1b5b[0-9]+3b[0-9]+52'
+  assert_probe_ok
+}
+
+@test "run: detached terminal client does not suppress later DA responses" {
+  # A real attach initializes terminal-client state. Ctrl-\ detaches it.
+  python3 - "$ZMX" "$ZMX_DIR" <<'PY'
+import os, pty, select, subprocess, sys, time
+zmx, zmx_dir = sys.argv[1], sys.argv[2]
+env = os.environ.copy()
+env["ZMX_DIR"] = zmx_dir
+master, slave = pty.openpty()
+proc = subprocess.Popen([zmx, "attach", "tq-sticky"], stdin=slave, stdout=slave, stderr=slave, env=env, close_fds=True)
+os.close(slave)
+deadline = time.time() + 2
+while time.time() < deadline:
+    readable, _, _ = select.select([master], [], [], 0.05)
+    if readable:
+        try:
+            os.read(master, 4096)
+        except OSError:
+            break
+    if proc.poll() is not None:
+        break
+os.write(master, b"\x1c")
+proc.wait(timeout=3)
+os.close(master)
+PY
+
+  wait_for_session tq-sticky
+  run terminal_query_probe --mode run --session tq-sticky --query '\033[c' --expect 1b5b3f36323b323263
+  assert_probe_ok
+}

--- a/test/terminal_query_probe.py
+++ b/test/terminal_query_probe.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import re
+import struct
+import subprocess
+import sys
+import textwrap
+from typing import Optional
+
+
+def frames_to_text(data: bytes) -> str:
+    i = 0
+    out = bytearray()
+    while i + 5 <= len(data):
+        tag = data[i]
+        size = struct.unpack_from("<I", data, i + 1)[0]
+        i += 5
+        if i + size > len(data):
+            break
+        payload = data[i : i + size]
+        i += size
+        if tag in (1, 14, 15):
+            out.extend(payload)
+    return out.decode("utf-8", errors="backslashreplace")
+
+
+def python_probe_code(query: Optional[str], split: bool) -> str:
+    if split:
+        writes = "os.write(1, b'\\x1b['); time.sleep(0.05); os.write(1, b'c')"
+    else:
+        assert query is not None
+        query_bytes = query.encode("utf-8").decode("unicode_escape").encode("latin1")
+        writes = f"os.write(1, {query_bytes!r})"
+    return textwrap.dedent(
+        f"""
+        import os, select, sys, termios, time, tty
+        fd = 0
+        old = termios.tcgetattr(fd)
+        try:
+            tty.setraw(fd)
+            {writes}
+            deadline = time.time() + 2.0
+            chunks = []
+            while time.time() < deadline and sum(len(c) for c in chunks) < 64:
+                readable, _, _ = select.select([fd], [], [], max(0, deadline - time.time()))
+                if not readable:
+                    break
+                chunk = os.read(fd, 64)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            resp = b''.join(chunks)
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old)
+        print('')
+        print('RESP_HEX=' + resp.hex())
+        print('DONE')
+        """
+    ).strip()
+
+
+def extract_hex(text: str) -> str | None:
+    matches = re.findall(r"RESP_HEX=([0-9a-f]*)", text)
+    return matches[-1] if matches else None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=["run", "control"], required=True)
+    parser.add_argument("--session", required=True)
+    parser.add_argument("--query")
+    parser.add_argument("--split", action="store_true")
+    parser.add_argument("--expect")
+    parser.add_argument("--expect-regex")
+    args = parser.parse_args()
+
+    zmx = os.environ["ZMX"]
+    env = os.environ.copy()
+    env.setdefault("SHELL", "/bin/bash")
+    code = python_probe_code(args.query, args.split)
+    if args.mode == "control":
+        cmd = [zmx, "control", "--rows", "24", "--cols", "80", args.session, "python3", "-c", code]
+    else:
+        cmd = [zmx, "run", args.session, "python3", "-c", code]
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, timeout=8, check=False)
+    text = frames_to_text(proc.stdout) if args.mode == "control" else proc.stdout.decode("utf-8", errors="backslashreplace")
+    if proc.stderr:
+        text += "\n[stderr]\n" + proc.stderr.decode("utf-8", errors="replace")
+    got = extract_hex(text)
+    print(text)
+    print(f"GOT_HEX={got!r}")
+    if args.expect is not None:
+        return 0 if got == args.expect else 1
+    if args.expect_regex is not None:
+        return 0 if got is not None and re.fullmatch(args.expect_regex, got) else 1
+    parser.error("one of --expect or --expect-regex is required")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Treat only real terminal clients as PTY terminal-query responders
- Keep daemon-side query responses enabled for control-only and tail-only sessions
- Handle split terminal queries, DA1/DA2 variants, DSR status, and CPR when no real terminal client is attached
- Add regression coverage for zmx control, split PTY reads, DSR/CPR, and detached-terminal responder state

## Problem
`zmx control` clients consume rendered frames but do not behave like real terminal emulators: they do not send terminal-query responses back to the PTY. Previously, control initialization marked the session as having a terminal client, which suppressed daemon-side DA responses. Shells and prompts that query terminal capabilities could then stall until a timeout or unrelated user input.

The daemon-level flag was also sticky: after a real terminal client detached, later tail/control-only usage could still suppress daemon responses.

## Approach
- Replace sticky daemon terminal-client state with a per-client `responds_to_terminal_queries` flag.
- Set that flag only for real `.Init` terminal clients, not `.ControlInit` clients.
- Derive responder presence from currently attached clients.
- Keep query response logic bounded to known terminal queries and a tiny suffix buffer for split PTY reads.
- Use ghostty-vt cursor state for CPR responses when no real terminal client is available.

## Verification
```sh
zig build test
bats test/terminal_queries.bats test/session.bats test/cli.bats
```

Result: 63/63 Bats tests passed, plus Zig tests passed.
