### PR TITLE
Harden control terminal edge cases

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -610,11 +610,23 @@ pub fn main() !void {
                 sessions.deinit(alloc);
             }
 
+            var matched_count: usize = 0;
+            var completed_count: usize = 0;
+            var completed_exit_code: u8 = 0;
+
             var fds = try std.ArrayList(i32).initCapacity(alloc, sessions.items.len);
             defer fds.deinit(alloc);
             for (sessions.items) |session| {
                 for (matchers.items) |m| {
                     if (!m.matches(session.name)) continue;
+                    matched_count += 1;
+                    if (!session.is_error and (session.task_ended_at orelse 0) > 0) {
+                        completed_count += 1;
+                        if ((session.task_exit_code orelse 0) != 0) {
+                            completed_exit_code = session.task_exit_code orelse 0;
+                        }
+                        break;
+                    }
                     const socket_path = socket.getSocketPath(alloc, cfg.socket_dir, session.name) catch |err| switch (err) {
                         error.NameTooLong => continue,
                         else => return err,
@@ -628,11 +640,15 @@ pub fn main() !void {
                     break;
                 }
             }
+            if (matched_count == 0) return error.SessionNotFound;
+            if (completed_count == matched_count) {
+                posix.exit(completed_exit_code);
+            }
             if (fds.items.len == 0) return error.SessionNotFound;
             defer for (fds.items) |fd| posix.close(fd);
 
             const exit_code = try tail(fds, false, false);
-            posix.exit(exit_code);
+            posix.exit(if (exit_code != 0) exit_code else completed_exit_code);
         },
 
         .kill => {
@@ -2361,13 +2377,27 @@ fn tail(client_socket_fds: std.ArrayList(i32), detached: bool, is_run_cmd: bool)
     var task_marker_buf = try std.ArrayList(u8).initCapacity(alloc, 128);
     defer task_marker_buf.deinit(alloc);
 
+    var active_fds = try std.ArrayList(i32).initCapacity(alloc, client_socket_fds.items.len);
+    defer active_fds.deinit(alloc);
+    try active_fds.appendSlice(alloc, client_socket_fds.items);
+
+    var completed_fds = try std.ArrayList(i32).initCapacity(alloc, client_socket_fds.items.len);
+    defer completed_fds.deinit(alloc);
+    var completed_codes = try std.ArrayList(u8).initCapacity(alloc, client_socket_fds.items.len);
+    defer completed_codes.deinit(alloc);
+
     var is_first_line = true;
     var task_complete_code: ?u8 = null;
+    var aggregate_exit_code: u8 = 0;
+    const post_task_idle_drain_ns: i128 = 50 * std.time.ns_per_ms;
+    const post_task_max_drain_ns: i128 = 500 * std.time.ns_per_ms;
+    var post_task_idle_deadline_ns: ?i128 = null;
+    var post_task_max_deadline_ns: ?i128 = null;
 
     while (true) {
         poll_fds.clearRetainingCapacity();
 
-        for (client_socket_fds.items) |client_sock_fd| {
+        for (active_fds.items) |client_sock_fd| {
             try poll_fds.append(alloc, .{
                 .fd = client_sock_fd,
                 .events = posix.POLL.IN,
@@ -2383,7 +2413,17 @@ fn tail(client_socket_fds: std.ArrayList(i32), detached: bool, is_run_cmd: bool)
             });
         }
 
-        _ = posix.poll(poll_fds.items, -1) catch |err| {
+        var poll_timeout_ms: i32 = -1;
+        if (post_task_idle_deadline_ns) |idle_deadline| {
+            const now = std.time.nanoTimestamp();
+            const max_deadline = post_task_max_deadline_ns orelse idle_deadline;
+            const deadline = @min(idle_deadline, max_deadline);
+            if (stdout_buf.items.len == 0 and now >= deadline) return aggregate_exit_code;
+            const remaining_ns = @max(@as(i128, 0), deadline - now);
+            poll_timeout_ms = @intCast(@max(@as(i128, 1), @divTrunc(remaining_ns + std.time.ns_per_ms - 1, std.time.ns_per_ms)));
+        }
+
+        _ = posix.poll(poll_fds.items, poll_timeout_ms) catch |err| {
             if (err == error.Interrupted) continue;
             return err;
         };
@@ -2410,6 +2450,9 @@ fn tail(client_socket_fds: std.ArrayList(i32), detached: bool, is_run_cmd: bool)
                         },
                         .Output => {
                             if (msg.payload.len > 0) {
+                                if (post_task_idle_deadline_ns != null) {
+                                    post_task_idle_deadline_ns = std.time.nanoTimestamp() + post_task_idle_drain_ns;
+                                }
                                 if (is_run_cmd and task_complete_code == null) {
                                     try task_marker_buf.appendSlice(alloc, msg.payload);
                                     task_complete_code = util.findTaskExitMarker(task_marker_buf.items);
@@ -2437,7 +2480,12 @@ fn tail(client_socket_fds: std.ArrayList(i32), detached: bool, is_run_cmd: bool)
                             }
                         },
                         .TaskComplete => {
-                            task_complete_code = if (msg.payload.len > 0) msg.payload[0] else 0;
+                            const exit_code = if (msg.payload.len > 0) msg.payload[0] else 0;
+                            task_complete_code = exit_code;
+                            if (std.mem.indexOfScalar(i32, completed_fds.items, poll_fd.fd) == null) {
+                                try completed_fds.append(alloc, poll_fd.fd);
+                                try completed_codes.append(alloc, exit_code);
+                            }
                         },
                         else => {},
                     }
@@ -2455,15 +2503,32 @@ fn tail(client_socket_fds: std.ArrayList(i32), detached: bool, is_run_cmd: bool)
             }
         }
 
-        if (stdout_buf.items.len == 0) {
-            if (task_complete_code) |exit_code| {
-                return exit_code;
+        if (stdout_buf.items.len == 0 and completed_fds.items.len > 0) {
+            for (completed_fds.items, completed_codes.items) |completed_fd, exit_code| {
+                if (exit_code != 0) aggregate_exit_code = exit_code;
+                if (is_run_cmd) {
+                    if (post_task_idle_deadline_ns == null) {
+                        const now = std.time.nanoTimestamp();
+                        post_task_idle_deadline_ns = now + post_task_idle_drain_ns;
+                        post_task_max_deadline_ns = now + post_task_max_drain_ns;
+                    }
+                    continue;
+                }
+                if (std.mem.indexOfScalar(i32, active_fds.items, completed_fd)) |idx| {
+                    try active_fds.replaceRange(alloc, idx, 1, &[_]i32{});
+                }
             }
+            completed_fds.clearRetainingCapacity();
+            completed_codes.clearRetainingCapacity();
+            if (!is_run_cmd and active_fds.items.len == 0) return aggregate_exit_code;
         }
 
         for (poll_fds.items) |poll_fd| {
             if (poll_fd.revents & (posix.POLL.HUP | posix.POLL.ERR | posix.POLL.NVAL) != 0) {
-                return 0;
+                if (std.mem.indexOfScalar(i32, active_fds.items, poll_fd.fd)) |idx| {
+                    try active_fds.replaceRange(alloc, idx, 1, &[_]i32{});
+                }
+                if (active_fds.items.len == 0) return aggregate_exit_code;
             }
         }
     }

--- a/src/util.zig
+++ b/src/util.zig
@@ -274,6 +274,19 @@ test "terminal query responder: ignores terminal responses" {
     try expectTerminalQueryResponse("\x1b[12;34R", "");
 }
 
+test "terminal query responder: abandons non-query CSI prefixes" {
+    try expectSplitTerminalQueryResponse("\x1b[", "x\x1b[c", DA1_RESPONSE);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    var pending: std.ArrayList(u8) = .empty;
+    defer pending.deinit(std.testing.allocator);
+    respondToTerminalQueries(std.testing.allocator, &buf, &pending, "\x1b[", 12, 34);
+    respondToTerminalQueries(std.testing.allocator, &buf, &pending, "x", 12, 34);
+    respondToTerminalQueries(std.testing.allocator, &buf, &pending, "\x1b[c", 12, 34);
+    try std.testing.expectEqualStrings(DA1_RESPONSE, buf.items);
+}
+
 /// OSC 133;A (prompt start) marker.
 const OSC_133_A = "\x1b]133;A";
 
@@ -304,11 +317,11 @@ pub fn rewritePromptRedraw(alloc: std.mem.Allocator, data: []const u8) ?[]const 
         const after = pos + OSC_133_A.len;
         if (after >= result.items.len) continue;
 
-        // Find the string terminator (BEL \x07 or ST \x1b\\).
+        // Find the string terminator (BEL \x07, 7-bit ST \x1b\\, or C1 ST \x9c).
         var term_pos: ?usize = null;
         var j = after;
         while (j < result.items.len) : (j += 1) {
-            if (result.items[j] == '\x07') {
+            if (result.items[j] == '\x07' or result.items[j] == '\x9c') {
                 term_pos = j;
                 break;
             }
@@ -322,16 +335,13 @@ pub fn rewritePromptRedraw(alloc: std.mem.Allocator, data: []const u8) ?[]const 
         // Check the parameter region between OSC_133_A and the terminator.
         const params = result.items[after..end];
 
-        // If redraw=0 already present, skip.
-        if (std.mem.indexOf(u8, params, "redraw=0") != null) continue;
-
-        // If redraw= exists with a different value, replace it.
-        if (std.mem.indexOf(u8, params, "redraw=")) |rdw_offset| {
-            const abs_rdw = after + rdw_offset;
-            const value_start = abs_rdw + "redraw=".len;
-            var value_end = value_start;
-            while (value_end < end and result.items[value_end] != ';') : (value_end += 1) {}
-            result.replaceRange(alloc, value_start, value_end - value_start, "0") catch return null;
+        // If redraw= is already present, only preserve an exact redraw=0
+        // parameter. Do not let values like redraw=01 or aid=redraw=0 suppress
+        // the rewrite.
+        if (findRedrawParam(params)) |rdw| {
+            if (rdw.is_zero) continue;
+            const value_start = after + rdw.value_start;
+            result.replaceRange(alloc, value_start, rdw.value_end - rdw.value_start, "0") catch return null;
             continue;
         }
 
@@ -346,6 +356,33 @@ pub fn rewritePromptRedraw(alloc: std.mem.Allocator, data: []const u8) ?[]const 
     }
 
     return result.toOwnedSlice(alloc) catch null;
+}
+
+const RedrawParam = struct {
+    value_start: usize,
+    value_end: usize,
+    is_zero: bool,
+};
+
+fn findRedrawParam(params: []const u8) ?RedrawParam {
+    var start: usize = 0;
+    while (start <= params.len) {
+        var end = start;
+        while (end < params.len and params[end] != ';') : (end += 1) {}
+        const param = params[start..end];
+        if (std.mem.startsWith(u8, param, "redraw=")) {
+            const value_start = start + "redraw=".len;
+            const value = params[value_start..end];
+            return .{
+                .value_start = value_start,
+                .value_end = end,
+                .is_zero = std.mem.eql(u8, value, "0"),
+            };
+        }
+        if (end == params.len) break;
+        start = end + 1;
+    }
+    return null;
 }
 
 test "rewritePromptRedraw: no OSC 133;A returns null" {
@@ -367,6 +404,13 @@ test "rewritePromptRedraw: injects redraw=0 with ST terminator" {
     try std.testing.expectEqualStrings("\x1b]133;A;redraw=0\x1b\\", result);
 }
 
+test "rewritePromptRedraw: injects redraw=0 with C1 ST terminator" {
+    const input = "\x1b]133;A\x9c";
+    const result = rewritePromptRedraw(std.testing.allocator, input).?;
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("\x1b]133;A;redraw=0\x9c", result);
+}
+
 test "rewritePromptRedraw: replaces existing redraw=1" {
     const input = "\x1b]133;A;redraw=1\x07";
     const result = rewritePromptRedraw(std.testing.allocator, input).?;
@@ -386,6 +430,20 @@ test "rewritePromptRedraw: preserves redraw=0 (no-op)" {
     try std.testing.expect(result == null);
 }
 
+test "rewritePromptRedraw: treats redraw=0 as exact parameter" {
+    const input = "\x1b]133;A;redraw=01\x07";
+    const result = rewritePromptRedraw(std.testing.allocator, input).?;
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("\x1b]133;A;redraw=0\x07", result);
+}
+
+test "rewritePromptRedraw: ignores redraw=0 inside other parameter values" {
+    const input = "\x1b]133;A;aid=redraw=0\x07";
+    const result = rewritePromptRedraw(std.testing.allocator, input).?;
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("\x1b]133;A;aid=redraw=0;redraw=0\x07", result);
+}
+
 test "rewritePromptRedraw: preserves other parameters" {
     const input = "\x1b]133;A;aid=14;cl=line\x07";
     const result = rewritePromptRedraw(std.testing.allocator, input).?;
@@ -398,6 +456,13 @@ test "rewritePromptRedraw: handles multiple markers" {
     const result = rewritePromptRedraw(std.testing.allocator, input).?;
     defer std.testing.allocator.free(result);
     try std.testing.expectEqualStrings("before\x1b]133;A;redraw=0\x07middle\x1b]133;A;redraw=0\x07after", result);
+}
+
+test "rewritePromptRedraw: handles adjacent mixed terminator markers" {
+    const input = "\x1b]133;A\x07\x1b]133;A;redraw=1\x1b\\\x1b]133;A;aid=7\x9c";
+    const result = rewritePromptRedraw(std.testing.allocator, input).?;
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("\x1b]133;A;redraw=0\x07\x1b]133;A;redraw=0\x1b\\\x1b]133;A;aid=7;redraw=0\x9c", result);
 }
 
 test "rewritePromptRedraw: does not touch OSC 133;B or 133;C" {
@@ -419,7 +484,17 @@ pub fn findTaskExitMarker(output: []const u8) ?u8 {
     var offset: usize = 0;
     while (offset < output.len) {
         const idx = std.mem.indexOf(u8, output[offset..], marker) orelse return null;
-        const after_marker = output[offset + idx + marker.len ..];
+        const marker_start = offset + idx;
+        var line_start = marker_start;
+        while (line_start > 0 and output[line_start - 1] != '\n' and output[line_start - 1] != '\r') {
+            line_start -= 1;
+        }
+        if (!isAnsiOnly(output[line_start..marker_start])) {
+            offset = marker_start + marker.len;
+            continue;
+        }
+
+        const after_marker = output[marker_start + marker.len ..];
 
         // Find the exit code number and newline
         var end_idx: usize = 0;
@@ -432,9 +507,9 @@ pub fn findTaskExitMarker(output: []const u8) ?u8 {
         // Shells echo the submitted command before running it, which can expose
         // the literal marker template (for example `ZMX_TASK_COMPLETED:$?`).
         // Keep scanning until we find the marker emitted with a numeric code.
-        if (std.fmt.parseInt(u8, exit_code_str, 10)) |exit_code| {
+        if (parseTaskExitCode(exit_code_str)) |exit_code| {
             return exit_code;
-        } else |_| {
+        } else {
             offset += idx + marker.len;
         }
     }
@@ -442,11 +517,68 @@ pub fn findTaskExitMarker(output: []const u8) ?u8 {
     return null;
 }
 
+fn isAnsiOnly(data: []const u8) bool {
+    var i: usize = 0;
+    while (i < data.len) {
+        if (i + 2 > data.len or data[i] != '\x1b' or data[i + 1] != '[') return false;
+        i += 2;
+        while (i < data.len) : (i += 1) {
+            if (data[i] >= 0x40 and data[i] <= 0x7e) {
+                i += 1;
+                break;
+            }
+        } else return false;
+    }
+    return true;
+}
+
+fn parseTaskExitCode(data: []const u8) ?u8 {
+    var digits: [3]u8 = undefined;
+    var digits_len: usize = 0;
+
+    var i: usize = 0;
+    while (i < data.len) {
+        if (data[i] == '\x1b' and i + 1 < data.len and data[i + 1] == '[') {
+            i += 2;
+            while (i < data.len) : (i += 1) {
+                if (data[i] >= 0x40 and data[i] <= 0x7e) {
+                    i += 1;
+                    break;
+                }
+            }
+            continue;
+        }
+
+        if (data[i] < '0' or data[i] > '9') return null;
+        if (digits_len == digits.len) return null;
+        digits[digits_len] = data[i];
+        digits_len += 1;
+        i += 1;
+    }
+
+    if (digits_len == 0) return null;
+    return std.fmt.parseInt(u8, digits[0..digits_len], 10) catch null;
+}
+
 test "findTaskExitMarker skips echoed marker template" {
     try std.testing.expectEqual(
         @as(?u8, 0),
         findTaskExitMarker("echo ZMX_TASK_COMPLETED:$?\r\nhello\r\nZMX_TASK_COMPLETED:0\r\n"),
     );
+}
+
+test "findTaskExitMarker handles practical marker variants" {
+    try std.testing.expectEqual(@as(?u8, 7), findTaskExitMarker("ZMX_TASK_COMPLETED:7\r"));
+    try std.testing.expectEqual(@as(?u8, 1), findTaskExitMarker("\x1b[31mZMX_TASK_COMPLETED:1\r\n"));
+    try std.testing.expectEqual(
+        @as(?u8, 2),
+        findTaskExitMarker("ZMX_TASK_COMPLETED:$?\r\nZMX_TASK_COMPLETED:$status\r\nZMX_TASK_COMPLETED:2\r\n"),
+    );
+    try std.testing.expectEqual(@as(?u8, 3), findTaskExitMarker("progress 90%\rZMX_TASK_COMPLETED:3\r\n"));
+    try std.testing.expectEqual(@as(?u8, 4), findTaskExitMarker("ZMX_TASK_COMPLETED:\x1b[32m4\x1b[0m\r\n"));
+    try std.testing.expectEqual(@as(?u8, 5), findTaskExitMarker("ZMX_TASK_COMPLETED:999\r\nZMX_TASK_COMPLETED:5\r\n"));
+    try std.testing.expectEqual(@as(?u8, 6), findTaskExitMarker("NOT_ZMX_TASK_COMPLETED:0\r\nZMX_TASK_COMPLETED:6\r\n"));
+    try std.testing.expectEqual(@as(?u8, 8), findTaskExitMarker("\x1b[1m\x1b[32mZMX_TASK_COMPLETED:8\r\n"));
 }
 
 /// Detects Kitty keyboard protocol escape sequence for Ctrl+\.

--- a/test/tail_wait_status.bats
+++ b/test/tail_wait_status.bats
@@ -1,0 +1,222 @@
+#!/usr/bin/env bats
+# Curated tail/wait status and aggregation regressions for tricky session
+# completion, tailing, and prompt-drain behavior.
+
+load test_helper
+
+assert_ok_or_dump() {
+  if [ "$status" -ne 0 ]; then
+    echo "status=$status" >&3
+    echo "$output" >&3
+  fi
+  [ "$status" -eq 0 ]
+}
+
+assert_status_or_dump() {
+  local expected="$1"
+  if [ "$status" -ne "$expected" ]; then
+    echo "expected status=$expected actual=$status" >&3
+    echo "$output" >&3
+  fi
+  [ "$status" -eq "$expected" ]
+}
+
+start_task() {
+  local name="$1" delay="$2" marker="$3" exit_code="$4"
+  "$ZMX" run "$name" -d python3 -c "import os,time,sys; time.sleep($delay); os.write(1,b'$marker\\n'); sys.exit($exit_code)"
+  wait_for_session "$name"
+}
+
+settle_tasks() {
+  timeout 6 "$ZMX" wait "$@" >/dev/null 2>&1 || true
+}
+
+@test "tail: waits for all active sessions with mixed exits" {
+  start_task tmix-ok 0.25 TAIL_MIXED_OK 0
+  start_task tmix-f 0.55 TAIL_MIXED_FAIL 49
+
+  run timeout 8 "$ZMX" tail tmix-ok tmix-f
+  assert_status_or_dump 49
+  [[ "$output" == *"TAIL_MIXED_OK"* ]]
+  [[ "$output" == *"TAIL_MIXED_FAIL"* ]]
+  [[ "$output" == *"ZMX_TASK_COMPLETED:0"* ]]
+  [[ "$output" == *"ZMX_TASK_COMPLETED:49"* ]]
+}
+
+@test "tail: waits for all active sessions when all succeed" {
+  start_task tall-a 0.25 TAIL_ALL_OK_A 0
+  start_task tall-b 0.55 TAIL_ALL_OK_B 0
+
+  run timeout 8 "$ZMX" tail tall-a tall-b
+  assert_ok_or_dump
+  [[ "$output" == *"TAIL_ALL_OK_A"* ]]
+  [[ "$output" == *"TAIL_ALL_OK_B"* ]]
+  [[ "$output" == *"ZMX_TASK_COMPLETED:0"* ]]
+}
+
+@test "tail: waits for slower success after earlier failure" {
+  start_task tfail 0.25 TAIL_FAIL_FIRST 42
+  start_task tlate 0.65 TAIL_SUCCESS_LATER 0
+
+  run timeout 8 "$ZMX" tail tfail tlate
+  assert_status_or_dump 42
+  [[ "$output" == *"TAIL_FAIL_FIRST"* ]]
+  [[ "$output" == *"TAIL_SUCCESS_LATER"* ]]
+  [[ "$output" == *"ZMX_TASK_COMPLETED:42"* ]]
+  [[ "$output" == *"ZMX_TASK_COMPLETED:0"* ]]
+}
+
+@test "tail: handles three active sessions with mixed exits" {
+  start_task t3-ok-a 0.20 TAIL_THREE_OK_A 0
+  start_task t3-fail 0.45 TAIL_THREE_FAIL 47
+  start_task t3-ok-b 0.70 TAIL_THREE_OK_B 0
+
+  run timeout 9 "$ZMX" tail t3-ok-a t3-fail t3-ok-b
+  assert_status_or_dump 47
+  [[ "$output" == *"TAIL_THREE_OK_A"* ]]
+  [[ "$output" == *"TAIL_THREE_FAIL"* ]]
+  [[ "$output" == *"TAIL_THREE_OK_B"* ]]
+  [[ "$output" == *"ZMX_TASK_COMPLETED:47"* ]]
+}
+
+@test "wait: waits for all active sessions with mixed exits" {
+  start_task wmix-ok 0.25 WAIT_MIXED_OK 0
+  start_task wmix-f 0.55 WAIT_MIXED_FAIL 43
+
+  run timeout 8 "$ZMX" wait wmix-ok wmix-f
+  assert_status_or_dump 43
+  [[ "$output" == *"wmix-ok completed"* ]]
+  [[ "$output" == *"wmix-f exited (43)"* ]]
+  [[ "$output" == *"tasks failed"* ]]
+}
+
+@test "wait: waits for all active sessions when all succeed" {
+  start_task wall-a 0.25 WAIT_ALL_OK_A 0
+  start_task wall-b 0.55 WAIT_ALL_OK_B 0
+
+  run timeout 8 "$ZMX" wait wall-a wall-b
+  assert_ok_or_dump
+  [[ "$output" == *"wall-a completed"* ]]
+  [[ "$output" == *"wall-b completed"* ]]
+  [[ "$output" == *"all tasks completed"* ]]
+}
+
+@test "wait: waits for slower success after earlier failure" {
+  start_task wfail 0.25 WAIT_FAIL_FIRST 44
+  start_task wlate 0.65 WAIT_SUCCESS_LATER 0
+
+  run timeout 8 "$ZMX" wait wfail wlate
+  assert_status_or_dump 44
+  [[ "$output" == *"wfail exited (44)"* ]]
+  [[ "$output" == *"wlate completed"* ]]
+  [[ "$output" == *"tasks failed"* ]]
+}
+
+@test "tail: late completed sessions return remembered status without replay" {
+  start_task tl-a 0.10 TAIL_LATE_FAIL_A 41
+  start_task tl-b 0.15 TAIL_LATE_FAIL_B 42
+  settle_tasks tl-a tl-b
+
+  run timeout 5 "$ZMX" tail tl-a tl-b
+  if [ "$status" -ne 41 ] && [ "$status" -ne 42 ]; then
+    echo "expected status 41 or 42 actual=$status" >&3
+    echo "$output" >&3
+    false
+  fi
+  [[ "$output" != *"TAIL_LATE_FAIL_A"* ]]
+  [[ "$output" != *"TAIL_LATE_FAIL_B"* ]]
+  [[ "$output" != *"ZMX_TASK_COMPLETED"* ]]
+}
+
+@test "wait: late completed sessions report remembered status" {
+  start_task wl-ok 0.10 WAIT_LATE_OK 0
+  start_task wl-f 0.15 WAIT_LATE_FAIL 45
+  settle_tasks wl-ok wl-f
+
+  run timeout 5 "$ZMX" wait wl-ok wl-f
+  assert_status_or_dump 45
+  [[ "$output" == *"wl-ok completed"* ]]
+  [[ "$output" == *"wl-f exited (45)"* ]]
+  [[ "$output" == *"tasks failed"* ]]
+}
+
+@test "tail: completed plus running sessions combine remembered status with live output" {
+  start_task td-f 0.10 TAIL_DONE_FAIL 46
+  settle_tasks td-f
+  start_task tr-ok 0.45 TAIL_RUNNING_OK 0
+
+  run timeout 8 "$ZMX" tail td-f tr-ok
+  assert_status_or_dump 46
+  [[ "$output" == *"TAIL_RUNNING_OK"* ]]
+  [[ "$output" == *"ZMX_TASK_COMPLETED:0"* ]]
+  [[ "$output" != *"TAIL_DONE_FAIL"* ]]
+}
+
+@test "wait: completed plus running sessions combine remembered status with live wait" {
+  start_task wd-f 0.10 WAIT_DONE_FAIL 46
+  settle_tasks wd-f
+  start_task wr-ok 0.45 WAIT_RUNNING_OK 0
+
+  run timeout 8 "$ZMX" wait wd-f wr-ok
+  assert_status_or_dump 46
+  [[ "$output" == *"wd-f exited (46)"* ]]
+  [[ "$output" == *"wr-ok completed"* ]]
+  [[ "$output" == *"tasks failed"* ]]
+}
+
+@test "tail: wildcard active sessions with mixed exits" {
+  start_task ptt-ok 0.25 PREFIX_TAIL_OK 0
+  start_task ptt-fail 0.55 PREFIX_TAIL_FAIL 48
+
+  run timeout 8 "$ZMX" tail 'ptt-*'
+  assert_status_or_dump 48
+  [[ "$output" == *"PREFIX_TAIL_OK"* ]]
+  [[ "$output" == *"PREFIX_TAIL_FAIL"* ]]
+  [[ "$output" == *"ZMX_TASK_COMPLETED:48"* ]]
+}
+
+@test "wait: wildcard active sessions with mixed exits" {
+  start_task pwt-ok 0.25 PREFIX_WAIT_OK 0
+  start_task pwt-fail 0.55 PREFIX_WAIT_FAIL 48
+
+  run timeout 8 "$ZMX" wait 'pwt-*'
+  assert_status_or_dump 48
+  [[ "$output" == *"pwt-ok completed"* ]]
+  [[ "$output" == *"pwt-fail exited (48)"* ]]
+}
+
+@test "wait: ZMX_SESSION_PREFIX fallback with mixed exits" {
+  start_task ew-ok 0.25 ENV_WAIT_OK 0
+  start_task ew-f 0.55 ENV_WAIT_FAIL 49
+
+  run timeout 8 env ZMX_SESSION_PREFIX=ew- "$ZMX" wait
+  assert_status_or_dump 49
+  [[ "$output" == *"ew-ok completed"* ]]
+  [[ "$output" == *"ew-f exited (49)"* ]]
+}
+
+@test "tail: no-argument ZMX_SESSION_PREFIX remains an explicit unsupported entry path" {
+  start_task egap-one 0.25 ENV_TAIL_GAP 0
+
+  run timeout 5 env ZMX_SESSION_PREFIX=egap- "$ZMX" tail
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"ENV_TAIL_GAP"* ]]
+}
+
+@test "run: drains immediate zsh precmd output after task completion marker" {
+  if [ ! -x /bin/zsh ]; then
+    skip "/bin/zsh is required for this prompt-drain regression"
+  fi
+
+  run timeout 8 env SHELL=/bin/zsh "$ZMX" run pm-zsh eval "precmd(){ printf '\\033[36mPOST_MARKER_PRECMD\\033[0m'; }; false"
+  assert_status_or_dump 1
+
+  marker_index=$(printf '%s' "$output" | awk 'BEGIN{idx=-1} {pos=index($0,"ZMX_TASK_COMPLETED:1"); if (pos && idx < 0) idx=length(prefix)+pos; prefix=prefix $0 "\n"} END{print idx}')
+  prompt_index=$(printf '%s' "$output" | awk 'BEGIN{idx=-1} {pos=index($0,"POST_MARKER_PRECMD"); if (pos && idx < 0) idx=length(prefix)+pos; prefix=prefix $0 "\n"} END{print idx}')
+
+  if [ "$marker_index" -lt 0 ] || [ "$prompt_index" -le "$marker_index" ]; then
+    echo "marker_index=$marker_index prompt_index=$prompt_index" >&3
+    echo "$output" >&3
+    false
+  fi
+}

--- a/test/terminal_queries.bats
+++ b/test/terminal_queries.bats
@@ -36,11 +36,69 @@ assert_probe_ok() {
   assert_probe_ok
 }
 
+@test "control: answers split DA2, DSR, and CPR terminal queries" {
+  run terminal_query_probe --mode control --session tq-split-da2 --chunk '\033[' --chunk '>c' --expect 1b5b3e313b31303b3063
+  assert_probe_ok
+
+  run terminal_query_probe --mode control --session tq-split-da2x --chunk '\033[>' --chunk '0c' --expect 1b5b3e313b31303b3063
+  assert_probe_ok
+
+  run terminal_query_probe --mode control --session tq-split-dsr --chunk '\033[' --chunk '5n' --expect 1b5b306e
+  assert_probe_ok
+
+  run terminal_query_probe --mode control --session tq-split-cpr --chunk '\033[6' --chunk 'n' --expect-regex '1b5b[0-9]+3b[0-9]+52'
+  assert_probe_ok
+}
+
+@test "control: answers batched terminal queries in order" {
+  run terminal_query_probe --mode control --session tq-batched --chunk '\033[c\033[>c\033[5n' --expect 1b5b3f36323b3232631b5b3e313b31303b30631b5b306e
+  assert_probe_ok
+
+  run terminal_query_probe --mode control --session tq-batched-cpr --chunk '\033[c\033[6n' --expect-regex '1b5b3f36323b3232631b5b[0-9]+3b[0-9]+52'
+  assert_probe_ok
+}
+
+@test "control: answers queries without hiding surrounding output" {
+  run terminal_query_probe --mode control --session tq-outq --chunk 'before\033[cafter' --expect 1b5b3f36323b323263 --expect-text before --expect-text after
+  assert_probe_ok
+
+  run terminal_query_probe --mode control --session tq-outsplit --chunk 'before' --chunk '\033[' --chunk 'cafter' --expect 1b5b3f36323b323263 --expect-text before --expect-text after
+  assert_probe_ok
+}
+
 @test "control: answers DSR status and CPR cursor queries" {
   run terminal_query_probe --mode control --session tq-dsr --query '\033[5n' --expect 1b5b306e
   assert_probe_ok
 
   run terminal_query_probe --mode control --session tq-cpr --query '\033[6n' --expect-regex '1b5b[0-9]+3b[0-9]+52'
+  assert_probe_ok
+}
+
+@test "control: ignores unsupported query-like CSI variants" {
+  run terminal_query_probe --mode control --session tq-priv-dsr --query '\033[?6n' --expect ''
+  assert_probe_ok
+
+  run terminal_query_probe --mode control --session tq-da-param --query '\033[1c' --expect ''
+  assert_probe_ok
+}
+
+@test "control: filters mixed supported and unsupported CSI query batches" {
+  run terminal_query_probe --mode control --session tq-mix-csi --chunk '\033[?6n\033[c\033[1c\033[5n' --expect 1b5b3f36323b3232631b5b306e
+  assert_probe_ok
+}
+
+@test "control: split unsupported CSI prefix does not block later valid query" {
+  run terminal_query_probe --mode control --session tq-split-unsup --chunk '\033[?' --chunk '6n\033[c' --expect 1b5b3f36323b323263
+  assert_probe_ok
+}
+
+@test "control: repeated unsupported CSI bursts do not block later queries" {
+  run terminal_query_probe --mode control --session tq-unsup-burst --chunk '\033[?6n\033[1c\033[?6n\033[c\033[6n' --expect-regex '1b5b3f36323b3232631b5b[0-9]+3b[0-9]+52'
+  assert_probe_ok
+}
+
+@test "control: split unsupported CSI with output does not hide text or later query" {
+  run terminal_query_probe --mode control --session tq-unsup-out --chunk 'pre\033[?' --chunk '6nmid\033[cpost' --expect 1b5b3f36323b323263 --expect-text pre --expect-text mid --expect-text post
   assert_probe_ok
 }
 

--- a/test/terminal_query_probe.py
+++ b/test/terminal_query_probe.py
@@ -25,12 +25,20 @@ def frames_to_text(data: bytes) -> str:
     return out.decode("utf-8", errors="backslashreplace")
 
 
-def python_probe_code(query: Optional[str], split: bool) -> str:
-    if split:
+def escaped_bytes(text: str) -> bytes:
+    return text.encode("utf-8").decode("unicode_escape").encode("latin1")
+
+
+def python_probe_code(query: Optional[str], split: bool, chunks: list[str]) -> str:
+    if chunks:
+        writes = "; time.sleep(0.05); ".join(
+            f"os.write(1, {escaped_bytes(chunk)!r})" for chunk in chunks
+        )
+    elif split:
         writes = "os.write(1, b'\\x1b['); time.sleep(0.05); os.write(1, b'c')"
     else:
         assert query is not None
-        query_bytes = query.encode("utf-8").decode("unicode_escape").encode("latin1")
+        query_bytes = escaped_bytes(query)
         writes = f"os.write(1, {query_bytes!r})"
     return textwrap.dedent(
         f"""
@@ -71,14 +79,16 @@ def main() -> int:
     parser.add_argument("--session", required=True)
     parser.add_argument("--query")
     parser.add_argument("--split", action="store_true")
+    parser.add_argument("--chunk", action="append", default=[])
     parser.add_argument("--expect")
     parser.add_argument("--expect-regex")
+    parser.add_argument("--expect-text", action="append", default=[])
     args = parser.parse_args()
 
     zmx = os.environ["ZMX"]
     env = os.environ.copy()
     env.setdefault("SHELL", "/bin/bash")
-    code = python_probe_code(args.query, args.split)
+    code = python_probe_code(args.query, args.split, args.chunk)
     if args.mode == "control":
         cmd = [zmx, "control", "--rows", "24", "--cols", "80", args.session, "python3", "-c", code]
     else:
@@ -90,11 +100,19 @@ def main() -> int:
     got = extract_hex(text)
     print(text)
     print(f"GOT_HEX={got!r}")
+    ok = True
     if args.expect is not None:
-        return 0 if got == args.expect else 1
-    if args.expect_regex is not None:
-        return 0 if got is not None and re.fullmatch(args.expect_regex, got) else 1
-    parser.error("one of --expect or --expect-regex is required")
+        ok = ok and got == args.expect
+    elif args.expect_regex is not None:
+        ok = ok and got is not None and re.fullmatch(args.expect_regex, got) is not None
+    else:
+        parser.error("one of --expect or --expect-regex is required")
+
+    for expected_text in args.expect_text:
+        if expected_text not in text:
+            print(f"MISSING_TEXT={expected_text!r}")
+            ok = False
+    return 0 if ok else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR promotes the control/tail terminal edge-case work into a clean, reviewable change without carrying over any autoresearch bookkeeping or scratch artifacts.

It hardens three related areas:

- daemon-side terminal query handling and marker parsing for tricky split/escaped output
- multi-session `tail`/`wait` task-status aggregation
- blocking `zmx run` output draining after task completion markers

## Rationale

Recent fixes made `zmx control`, `zmx run`, and tail-only clients much more sensitive to terminal sequencing details: shell prompts emit terminal queries, shells echo command text, completion markers can be split across reads, and prompt hooks can write output immediately after the daemon-appended `ZMX_TASK_COMPLETED:<code>` marker.

Those cases are easy to regress because they depend on PTY chunking and timing rather than simple command output. The goal here is to turn the practical edge cases we found into normal regression coverage, while keeping the runtime fixes small and scoped.

## What changed

### Terminal query and marker hardening

- Expanded terminal-query coverage for split and batched DA/DSR/CPR sequences.
- Preserved surrounding visible output when terminal queries appear in the same stream.
- Kept daemon-side query responses scoped to control/run clients that do not have a real terminal responder.
- Hardened task completion marker parsing so echoed marker templates and ANSI-wrapped markers do not confuse exit-code detection.

### Tail/wait status corpus

Added `test/tail_wait_status.bats`, a curated Bats corpus covering:

- active multi-tail mixed exits
- active multi-tail all-success
- earlier failure followed by later success
- three active tailed sessions
- matching multi-wait cases
- late tail/wait over already-completed sessions
- completed + running session aggregation
- wildcard prefix tail/wait aggregation
- `ZMX_SESSION_PREFIX` fallback for `wait`
- explicit documentation that no-argument `tail` still does **not** use `ZMX_SESSION_PREFIX`

The test session names are intentionally short so they remain reliable with macOS Unix socket path limits under Bats temp directories.

### Bounded post-marker drain for `zmx run`

Blocking `zmx run` previously could return as soon as the task-completion marker was observed, which meant prompt output emitted immediately afterward by shells such as zsh could be dropped depending on PTY scheduling.

This adds a bounded post-task drain window for blocking run clients:

- idle drain window: 50ms
- hard maximum drain window: 500ms

That preserves immediate prompt hook output after `ZMX_TASK_COMPLETED:<code>` without allowing an unbounded tail or changing detached-run behavior.

## Intentional non-change: `tail` vs `wait` env-prefix behavior

`zmx wait` supports no-argument fallback through `ZMX_SESSION_PREFIX`, which is useful for status-oriented batch scripts.

`zmx tail` still requires explicit session matchers and returns `SessionNameRequired` with no arguments. This PR preserves that behavior and adds a regression test documenting it. Streaming output for an implicit prefix batch is more surprising than waiting for statuses, so any future symmetry change should be a deliberate UX decision rather than incidental drift.

## Exclusions

This PR intentionally excludes all autoresearch files and scratch artifacts. The branch only contains production code and reproducible tests.

## Verification

Ran locally:

```sh
bats test/tail_wait_status.bats
zig build test
bats test
```

Full Bats suite passed: 87/87.
